### PR TITLE
revert serde to 1.0.171

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -712,18 +712,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.176"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76dc28c9523c5d70816e393136b86d48909cfb27cecaa902d338c19ed47164dc"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.176"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e7b8c5dc823e3b90651ff1d3808419cd14e5ad76de04feaf37da114e7a306f"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ axum = "0.6.19"
 menv = "0.2.7"
 rand = "0.8.5"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
-serde = { version = "1.0.176", features = ["derive"] }
+serde = { version = "=1.0.171", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["full"] }
 tower-http = { version = "0.4.3", features = ["auth"] }
 tracing = "0.1.37"


### PR DESCRIPTION
I didn't notice this while pressed for time, but serde's maintainer made a poor security affecting decision in the name of a tiny boost to compiler performance. We'll want to revert to the last version before that until that situation is sorted out.

To be clear, this is not an *urgent* security fix. We just don't want to sit on our hands while someone breaks our build reproducibility.