### PR TITLE
Fix error handling

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,7 +1,7 @@
-use std::convert::Infallible;
+use crate::{GuildId, QuestId, UserId};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use crate::{GuildId, QuestId, UserId};
+use std::convert::Infallible;
 
 // TODO: We could plausibly split a lot of the error types out of this,
 //  to make the return type of each endpoint more specific.
@@ -42,7 +42,9 @@ pub(crate) enum Error<E = Infallible> {
     UnauthorizedLogin,
     SessionNotFound,
     // TODO: decide how to model this
-    InsufficientPermissions { msg: String },
+    InsufficientPermissions {
+        msg: String,
+    },
     Other(E),
 }
 
@@ -58,55 +60,70 @@ impl<E: IntoResponse> IntoResponse for Error<E> {
             Self::DbError(e) => {
                 tracing::error!("rusqlite error: {e:?}");
                 (StatusCode::INTERNAL_SERVER_ERROR, "database access failed").into_response()
-            },
+            }
             Self::AdventurerNotFound { id } => {
                 if let Some(id) = id {
-                    (StatusCode::NOT_FOUND, format!("no adventurer with id = {id} exists")).into_response()
+                    (
+                        StatusCode::NOT_FOUND,
+                        format!("no adventurer with id = {id} exists"),
+                    )
+                        .into_response()
                 } else {
                     (StatusCode::NOT_FOUND, "specified adventurer not found").into_response()
                 }
-            },
-            Self::AdventurerNotFoundByEmail { email } => {
-                (StatusCode::NOT_FOUND, format!("no adventurer with email = {email} exists")).into_response()
-            },
+            }
+            Self::AdventurerNotFoundByEmail { email } => (
+                StatusCode::NOT_FOUND,
+                format!("no adventurer with email = {email} exists"),
+            )
+                .into_response(),
             Self::GuildNotFound { id } => {
                 if let Some(id) = id {
-                    (StatusCode::NOT_FOUND, format!("no guild with id = {id} exists")).into_response()
+                    (
+                        StatusCode::NOT_FOUND,
+                        format!("no guild with id = {id} exists"),
+                    )
+                        .into_response()
                 } else {
                     (StatusCode::NOT_FOUND, "specified guild not found").into_response()
                 }
-            },
+            }
             Self::QuestNotFound { id } => {
                 if let Some(id) = id {
-                    (StatusCode::NOT_FOUND, format!("no quest with id = {id} exists")).into_response()
+                    (
+                        StatusCode::NOT_FOUND,
+                        format!("no quest with id = {id} exists"),
+                    )
+                        .into_response()
                 } else {
                     (StatusCode::NOT_FOUND, "specified quest not found").into_response()
                 }
-            },
-            Self::NotQuestMember { user_id, quest_id } => {
-                (StatusCode::BAD_REQUEST, format!("adventurer {user_id} is not a member of party for quest {quest_id}")).into_response()
-            },
-            Self::QuestNotBelongToGuild { quest_id, guild_id } => {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("quest {quest_id} does not belong to guild {guild_id}"),
-                ).into_response()
-            },
+            }
+            Self::NotQuestMember { user_id, quest_id } => (
+                StatusCode::BAD_REQUEST,
+                format!("adventurer {user_id} is not a member of party for quest {quest_id}"),
+            )
+                .into_response(),
+            Self::QuestNotBelongToGuild { quest_id, guild_id } => (
+                StatusCode::BAD_REQUEST,
+                format!("quest {quest_id} does not belong to guild {guild_id}"),
+            )
+                .into_response(),
             Self::AccountAlreadyExists => {
                 (StatusCode::BAD_REQUEST, "account already exists").into_response()
-            },
-            Self::CannotComputePasswordHash => {
-                (StatusCode::INTERNAL_SERVER_ERROR, "failed to compute password hash").into_response()
-            },
-            Self::UnauthorizedLogin => {
-                (StatusCode::UNAUTHORIZED, "failed login").into_response()
-            },
+            }
+            Self::CannotComputePasswordHash => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "failed to compute password hash",
+            )
+                .into_response(),
+            Self::UnauthorizedLogin => (StatusCode::UNAUTHORIZED, "failed login").into_response(),
             Self::SessionNotFound => {
                 (StatusCode::UNAUTHORIZED, "session not found").into_response()
-            },
+            }
             Self::InsufficientPermissions { msg } => {
                 (StatusCode::UNAUTHORIZED, msg).into_response()
-            },
+            }
             Self::Other(e) => e.into_response(),
         }
     }

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use crate::{GuildId, QuestId, UserId};
@@ -11,7 +12,7 @@ use crate::{GuildId, QuestId, UserId};
 /// so we should have *some* way of exiting a transaction
 /// on the failure path with arbitrary data.
 #[derive(Debug)]
-pub(crate) enum Error<E> {
+pub(crate) enum Error<E = Infallible> {
     DbError(rusqlite::Error),
     AdventurerNotFound {
         id: Option<UserId>,

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,0 +1,65 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use crate::{GuildId, QuestId, UserId};
+
+// See the `IntoResponse` impl below.
+/// Errors for which we have defined HTTP responses,
+/// and so can bubble up to the top.
+///
+/// [`Error::Other`] is, essentially, for workarounds.
+/// We require this error type when returning from a transaction,
+/// so we should have *some* way of exiting a transaction
+/// on the failure path with arbitrary data.
+#[derive(Debug)]
+pub(crate) enum Error<E> {
+    DbError(rusqlite::Error),
+    AdventurerNotFound {
+        id: Option<UserId>,
+    },
+    GuildNotFound {
+        id: Option<GuildId>,
+    },
+    QuestNotFound {
+        id: Option<QuestId>,
+    },
+    Other(E),
+}
+
+impl<E> From<rusqlite::Error> for Error<E> {
+    fn from(value: rusqlite::Error) -> Self {
+        Self::DbError(value)
+    }
+}
+
+impl<E: IntoResponse> IntoResponse for Error<E> {
+    fn into_response(self) -> Response {
+        match self {
+            Self::DbError(e) => {
+                tracing::error!("rusqlite error: {e:?}");
+                (StatusCode::INTERNAL_SERVER_ERROR, "database access failed").into_response()
+            },
+            Self::AdventurerNotFound { id } => {
+                if let Some(id) = id {
+                    (StatusCode::NOT_FOUND, format!("no adventurer with id = {id} exists")).into_response()
+                } else {
+                    (StatusCode::NOT_FOUND, "specified adventurer not found").into_response()
+                }
+            },
+            Self::GuildNotFound { id } => {
+                if let Some(id) = id {
+                    (StatusCode::NOT_FOUND, format!("no guild with id = {id} exists")).into_response()
+                } else {
+                    (StatusCode::NOT_FOUND, "specified guild not found").into_response()
+                }
+            },
+            Self::QuestNotFound { id } => {
+                if let Some(id) = id {
+                    (StatusCode::NOT_FOUND, format!("no quest with id = {id} exists")).into_response()
+                } else {
+                    (StatusCode::NOT_FOUND, "specified quest not found").into_response()
+                }
+            },
+            Self::Other(e) => e.into_response(),
+        }
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -153,11 +153,6 @@ impl AppState {
         Self { db }
     }
 
-    // TODO: make an error type to use instead of rusqlite::Error, and refactor.
-    //       I'm pretty sure I should've done a couple rollbacks for when an adventurer
-    //       doesn't exist, but that incorrect handling is not a show stopper.
-    //       Also, generally, I believe the error handling in this server could be
-    //       made substantially less verbose. But fixing that is a problem for after GenCon.
     // These transaction wrapper methods, conveniently, prevent any async code from being passed to them,
     // which is good because performing an await while we hold a lock on the database will cause a deadlock.
     fn read_transaction<T, E, F: FnOnce(&mut rusqlite::Transaction) -> Result<T, Error<E>>>(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,4 +1,5 @@
 mod db;
+mod error;
 
 use argon2::password_hash::{PasswordHashString, Salt, SaltString};
 use argon2::{password_hash, Argon2, PasswordHash, PasswordHasher};


### PR DESCRIPTION
In this PR, I define an `Error` type and replace every endpoint's error type with it.
This is part of the cleanup described in #26.

Note that, while this packs every kind of failure into one type, it would now be easy to incrementally split out specific classes of error into their own types and make the signature of each endpoint more specific.
