### PR TITLE
Set CORS headers and preflight responses

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,6 @@ rand = "0.8.5"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 serde = { version = "1.0.176", features = ["derive"] }
 tokio = { version = "1.29.1", features = ["full"] }
-tower-http = { version = "0.4.3", features = ["auth"] }
+tower-http = { version = "0.4.3", features = ["auth", "cors"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,6 +15,7 @@ use rusqlite::{named_params, OptionalExtension, ToSql};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use tower_http::cors::CorsLayer;
 
 mod env {
     use std::path::PathBuf;
@@ -121,6 +122,10 @@ async fn main() {
             put(auth_set_password),
         )
         .fallback(fallback)
+        // TODO: we're going to want to narrow this,
+        //  but it's currently the least of our worries
+        //  (remember, we're not yet even authenticating API requests)
+        .layer(CorsLayer::very_permissive())
         .with_state(state.clone());
 
     let addr = SocketAddr::from(([127, 0, 0, 1], env::port()));


### PR DESCRIPTION
As discussed in the meeting earlier, we need to set some permissive CORS headers and such in order to allow serving the API from a separate origin to the web frontend.

Strictly speaking, we could specify what origins are permitted, but this replicates what we're currently doing in production already with NGINX.

We will want to do a proper review of our Web security later, to prevent cross site silliness, but that is the least of our problems in that direction right now. It will go on the TODO list in #26.