### PR TITLE
Add an `add-admin` subcommand to the server binary.

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -35,6 +35,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +830,7 @@ dependencies = [
 name = "server"
 version = "0.1.0"
 dependencies = [
+ "argh",
  "argon2",
  "axum",
  "menv",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+argh = "0.1.12"
 argon2 = "0.5.1"
 axum = { version = "0.6.19", features = ["headers"] }
 menv = "0.2.7"

--- a/server/src/add_admin.rs
+++ b/server/src/add_admin.rs
@@ -1,0 +1,52 @@
+//! This module provides the `add-admin` subcommand, which creates
+//! a new admin user in the mounted database.
+
+use std::fmt::Debug;
+use std::io::Write;
+use std::str::FromStr;
+use crate::{AppState, db, Password, PermissionType};
+use argh::FromArgs;
+use std::sync::Arc;
+use crate::db::{Email, Name};
+
+/// Add a new admin user to the database.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "add-admin")]
+pub struct AddAdmin {}
+
+pub fn add_admin(state: Arc<AppState>) {
+    let email: Email = read_prop("email: ");
+    let name: Name = read_prop("name: ");
+    let password: Password = read_prop("password: ");
+
+    state.write_transaction(|db| {
+        let user = db::create_account(db, name, email, password)?;
+        db::set_user_permission(db, user, PermissionType::Approved, true)?;
+        db::set_user_permission(db, user, PermissionType::SuperUser, true)?;
+        Ok(())
+    }).unwrap();
+}
+
+fn read_prop<T: FromStr>(prompt: &str) -> T
+where T::Err: Debug
+{
+    let stdin = std::io::stdin();
+    let mut stderr = std::io::stderr();
+    let mut buf = String::with_capacity(64);
+    loop {
+        buf.clear();
+        stderr.write_all(prompt.as_bytes()).unwrap();
+        let n = stdin.read_line(&mut buf).unwrap();
+        if n == 0 {
+            continue
+        }
+
+        let res = T::from_str(buf.trim());
+        match res {
+            Ok(x) => return x,
+            Err(e) => {
+                stderr.write_fmt(format_args!("{e:?}")).unwrap();
+            }
+        }
+    }
+}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -45,6 +45,7 @@ pub(crate) enum Error<E = Infallible> {
     InsufficientPermissions {
         msg: String,
     },
+    #[allow(dead_code)]
     Other(E),
 }
 


### PR DESCRIPTION
As part of the work outlined in #41, this adds a subcommand to the server executable, for creating a new admin user to the mounted database.

In doing so, this also refactors the user creation endpoint to delegate to the same function in the `db` module.