### PR TITLE
Frontend Auth Implementation

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,13 +12,13 @@ import Login from './components/login';
 import SignUp from './components/signup';
 import { ProfileProvider } from './common/profilecontext';
 import ProtectedRoute from './components/protectedroute';
-import { AuthProvider } from './common/auth_context';
+import { DeiApiProvider } from './common/dei_api_context';
 
 
 function App() {
   return (
     <>
-    <AuthProvider>
+    <DeiApiProvider>
       <ProfileProvider>
         <NavigationBar />
         <Routes>
@@ -34,7 +34,7 @@ function App() {
             <Route path="signup" element={<SignUp />} />
         </Routes>
       </ProfileProvider>
-    </AuthProvider>
+    </DeiApiProvider>
     </>
   );
 }

--- a/client/src/common/dei_api_context.js
+++ b/client/src/common/dei_api_context.js
@@ -17,9 +17,9 @@ function set_auth_session(session) {
     }
 }
 
-const AuthContext = createContext();
+const DeiApiContext = createContext();
 
-const AuthProvider = ({ children }) => {
+const DeiApiProvider = ({ children }) => {
     const old_session_text = localStorage.getItem("login_session");
     const old_session = old_session_text !== null ? JSON.parse(old_session_text) : null;
     set_auth_session(old_session);
@@ -33,10 +33,10 @@ const AuthProvider = ({ children }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ session, setSession, deiClient }}>
+        <DeiApiContext.Provider value={{ session, setSession, deiClient }}>
             {children}
-        </AuthContext.Provider>
+        </DeiApiContext.Provider>
     );
 };
 
-export { AuthContext, AuthProvider };
+export { DeiApiContext, DeiApiProvider };

--- a/client/src/components/login.js
+++ b/client/src/components/login.js
@@ -3,7 +3,7 @@ import { useState, useContext} from 'react';
 import './login.css'
 import { ProfileContext } from '../common/profilecontext';
 import { Navigate, Link } from 'react-router-dom';
-import { AuthContext } from '../common/auth_context';
+import { DeiApiContext } from '../common/dei_api_context';
 
 export default function Login() {
 
@@ -12,7 +12,7 @@ export default function Login() {
     const [ user, setUser ] = useState(null);
     const [ errorMessage, setErrorMessage ] = useState('');
     const {profile, setProfile, setUsedGoogleLogin} = useContext(ProfileContext);
-    const { session, setSession, deiClient } = useContext(AuthContext);
+    const { session, setSession, deiClient } = useContext(DeiApiContext);
     const loginFailMessage = 'Login Failed! Please Try Again!';
 
     // const loginWithGoogle = useGoogleLogin({

--- a/client/src/contentpages/guildleadership.js
+++ b/client/src/contentpages/guildleadership.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { useEffect, useCallback, useState, useContext } from 'react';
-import { AuthContext } from '../common/auth_context';
 import { ProfileContext } from '../common/profilecontext';
 import Button from 'react-bootstrap/Button';
 import _ from 'lodash';
 import './guildmanagement.css';
+import { DeiApiContext } from "../common/dei_api_context";
 
 const GuildLeadership = () => {
   //state
@@ -12,7 +12,7 @@ const GuildLeadership = () => {
   const [targetGuildQuestAction, setTargetGuildQuestAction] = useState({id:-1, description: "", xp: ""});
   const [newGuildQuestActionCreation, setNewGuildQuestActionCreation] = useState(false);
   const [targetGuild, setTargetGuild] = useState({id:-1});
-  const { deiClient } = useContext(AuthContext);
+  const { deiClient } = useContext(DeiApiContext);
   const { profile } = useContext(ProfileContext);
 
   //initializing UseEffect

--- a/client/src/contentpages/guildmanagement.js
+++ b/client/src/contentpages/guildmanagement.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { useEffect, useState, useContext } from 'react';
-import { AuthContext } from '../common/auth_context';
 // import { ProfileContext } from '../common/profilecontext';
 import Button from 'react-bootstrap/Button';
 import './guildmanagement.css';
+import { DeiApiContext } from "../common/dei_api_context";
 
 const GuildManagement = () => {
 
@@ -12,7 +12,7 @@ const GuildManagement = () => {
   const [availableGuildLeaders, setAvailableGuildLeaders] = useState([]);
   const [targetGuild, setTargetGuild] = useState({id:-1, name:"", leader_id:-1, leader_name: ""});
   const [newGuildCreation, setNewGuildCreation] = useState(false);
-  const { deiClient } = useContext(AuthContext);
+  const { deiClient } = useContext(DeiApiContext);
   // const { profile } = useContext(ProfileContext);
 
   useEffect(()=>{

--- a/client/src/contentpages/myadventures.js
+++ b/client/src/contentpages/myadventures.js
@@ -1,13 +1,13 @@
 import React from "react";
 import { useEffect, useCallback, useState, useContext } from 'react';
-import { AuthContext } from '../common/auth_context';
 import { ProfileContext } from '../common/profilecontext';
 import Button from 'react-bootstrap/Button';
 import _ from 'lodash';
+import { DeiApiContext } from "../common/dei_api_context";
 
 
 const MyAdventures = () => {
-    const { deiClient } = useContext(AuthContext);
+    const { deiClient } = useContext(DeiApiContext);
     const { profile, setProfile, usedGoogleLogin, setUsedGoogleLogin } = useContext(ProfileContext);
     const [acceptedQuestActions, setAcceptedQuestActions] = useState([]);
     const [availableQuestActions, setAvailableGuildQuestActions] = useState([]);

--- a/client/src/contentpages/myhistory.js
+++ b/client/src/contentpages/myhistory.js
@@ -1,11 +1,11 @@
 import React from "react";
 import { useEffect, useState, useContext } from 'react';
-import { AuthContext } from '../common/auth_context';
 import { ProfileContext } from '../common/profilecontext';
+import { DeiApiContext } from "../common/dei_api_context";
 
 
 const MyHistory = () => {
-    const { deiClient } = useContext(AuthContext);
+    const { deiClient } = useContext(DeiApiContext);
     const { profile } = useContext(ProfileContext);
     const [completedQuestActions, setCompletedQuestActions] = useState([]);
     const [guilds, setGuilds] = useState([]);


### PR DESCRIPTION
So, we've long known that the only *necessary* work on the frontend to enable auth enforcement is to save the session token returned by the server and submit its `token` field using the `Authorization` header on every request.
I had intended to let someone else do this, since I'm not completely familiar with the frontend codebase, but here we are.

This sets up a React context to save the auth session and deal with loading it back up on page reloads.
It deals with setting the appropriate `Authorization` header via axios global configuration, to avoid needing to adjust every axios call site.

This completes the first task on the list at #51.