### PR TITLE
Implement basic repeatable quest UI

### DIFF
--- a/client/src/contentpages/guildleadership.js
+++ b/client/src/contentpages/guildleadership.js
@@ -96,7 +96,6 @@ const GuildLeadership = () => {
 
   const saveNewGuildQuestAction  = (guildId, guildQuestAction) => {
     let data = {description: guildQuestAction.description, xp: parseInt(guildQuestAction.xp), repeatable: guildQuestAction.repeatable};
-    console.log(data);
     axios.post(api_config.baseURL + "/guild/" + guildId + "/quest-action", data).then((response) => {
       let questId = response.data.quest_id;
 
@@ -159,10 +158,7 @@ const GuildLeadership = () => {
           <div>
             <input onChange={(event) => setXp(event.target.value)} value={xp} /> xp
             &nbsp;
-            <input onChange={(event) => {
-              console.log(event.target.checked);
-              return setRepeatable(event.target.checked);
-            }} value={repeatable} type="checkbox"/> repeatable
+            <input onChange={(event) => setRepeatable(event.target.checked)} checked={repeatable} type="checkbox"/> repeatable
           </div>
         </div>
           <div className="actions">
@@ -179,7 +175,11 @@ const GuildLeadership = () => {
         <div className="listing">
           <div className="details">
             <div>{guildQuestAction.description}</div>
-            <div>{guildQuestAction.xp} xp</div>
+            <div>
+              {guildQuestAction.xp} xp
+              &nbsp;
+              <input type="checkbox" checked={guildQuestAction.repeatable} readOnly /> repeatable
+            </div>
           </div>
             <div className="actions">
               <Button variant="dark" onClick={() => setTargetGuildQuestAction(guildQuestAction)}>Edit</Button>&nbsp;

--- a/client/src/contentpages/guildleadership.js
+++ b/client/src/contentpages/guildleadership.js
@@ -10,7 +10,7 @@ import api_config from '../api_config.json'
 const GuildLeadership = () => {
   //state
   const [guildQuestActions, setGuildQuestActions] = useState([]);
-  const [targetGuildQuestAction, setTargetGuildQuestAction] = useState({id:-1, description: "", xp: ""});
+  const [targetGuildQuestAction, setTargetGuildQuestAction] = useState({id:-1, description: "", xp: "", repeatable: false });
   const [newGuildQuestActionCreation, setNewGuildQuestActionCreation] = useState(false);
   const [targetGuild, setTargetGuild] = useState({id:-1});
   const { profile } = useContext(ProfileContext);
@@ -45,7 +45,7 @@ const GuildLeadership = () => {
   //function components
   const editGuildQuestAction = (guildId, guildQuestAction) => {
 
-    const data = {quest_id: guildQuestAction.id, description: guildQuestAction.description, xp: parseInt(guildQuestAction.xp)};
+    const data = {quest_id: guildQuestAction.id, description: guildQuestAction.description, xp: parseInt(guildQuestAction.xp), repeatable: guildQuestAction.repeatable};
     
     axios.put(api_config.baseURL + "/guild/" + guildId + "/quest-action", data).then((response) => {});
 
@@ -56,7 +56,7 @@ const GuildLeadership = () => {
             guildQuestActions: 
               e.guildQuestActions.map((f) => {
                 if (f.id === guildQuestAction.id){
-                  return {...f, description: guildQuestAction.description, xp: guildQuestAction.xp};
+                  return {...f, description: guildQuestAction.description, xp: guildQuestAction.xp, repeatable: guildQuestAction.repeatable};
                 }
                 return {...f};
               })
@@ -65,7 +65,7 @@ const GuildLeadership = () => {
         return _.cloneDeep(e);
       });
     setGuildQuestActions(currentGuildQuestActions);
-    setTargetGuildQuestAction({id:-1, description: null, xp: null});
+    setTargetGuildQuestAction({id:-1, description: null, xp: null, repeatable: false});
     setTargetGuild({id:-1});
   };
 
@@ -85,7 +85,7 @@ const GuildLeadership = () => {
       });
 
     setGuildQuestActions(currentGuildQuestActions);
-    setTargetGuildQuestAction({id:-1, description: null, xp: null});
+    setTargetGuildQuestAction({id:-1, description: null, xp: null, repeatable: false});
     setTargetGuild({id:-1});
 
   };
@@ -95,7 +95,8 @@ const GuildLeadership = () => {
   }  
 
   const saveNewGuildQuestAction  = (guildId, guildQuestAction) => {
-    let data = {description: guildQuestAction.description, xp: parseInt(guildQuestAction.xp)};
+    let data = {description: guildQuestAction.description, xp: parseInt(guildQuestAction.xp), repeatable: guildQuestAction.repeatable};
+    console.log(data);
     axios.post(api_config.baseURL + "/guild/" + guildId + "/quest-action", data).then((response) => {
       let questId = response.data.quest_id;
 
@@ -129,7 +130,7 @@ const GuildLeadership = () => {
 
             <TargetQuestAction 
                 guildId = {guildId}
-                guildQuestAction={{id:-2, description: "", xp: ""}}
+                guildQuestAction={{id:-2, description: "", xp: "", repeatable: false }}
                 editGuildQuestAction={saveNewGuildQuestAction}
                 cancelEditGuildQuestAction={cancelNewGuildQuestAction}
               />
@@ -149,15 +150,23 @@ const GuildLeadership = () => {
   const TargetQuestAction = ({guildId, guildQuestAction, editGuildQuestAction, cancelEditGuildQuestAction}) => {
     const [description, setDescription] = useState(guildQuestAction.description);
     const [xp, setXp] = useState(guildQuestAction.xp);
+    const [repeatable, setRepeatable] = useState(guildQuestAction.repeatable);
 
     return (
       <div className="listing">
         <div className="details">
           <div>Description:&nbsp;<input className="wide-input" onChange={(event) => setDescription(event.target.value)} value={description} /></div>
-          <div><input onChange={(event) => setXp(event.target.value)} value={xp} /> xp</div>
+          <div>
+            <input onChange={(event) => setXp(event.target.value)} value={xp} /> xp
+            &nbsp;
+            <input onChange={(event) => {
+              console.log(event.target.checked);
+              return setRepeatable(event.target.checked);
+            }} value={repeatable} type="checkbox"/> repeatable
+          </div>
         </div>
           <div className="actions">
-            <Button variant="dark" onClick={() => editGuildQuestAction(guildId, {...guildQuestAction, xp: Number.isSafeInteger(Number.parseInt(xp)) ? xp : -1, description: description})}>Done</Button>&nbsp;
+            <Button variant="dark" onClick={() => editGuildQuestAction(guildId, {...guildQuestAction, xp: Number.isSafeInteger(Number.parseInt(xp)) ? xp : -1, description: description, repeatable: repeatable})}>Done</Button>&nbsp;
             <Button variant="dark" onClick={() => cancelEditGuildQuestAction()}>Cancel</Button>
           </div>
       </div>

--- a/client/src/contentpages/myadventures.js
+++ b/client/src/contentpages/myadventures.js
@@ -105,9 +105,7 @@ const MyAdventures = () => {
       const AvailableQuestAction = ({questAction}) => {
         return (
             <tr>
-                <td className="action-table-td left-col">{questAction.description}</td>
-                {/* todo: figure out the right way to display whether a quest is repeatable here */}
-                {/* <td className="action-table-td left-col">{questAction.repeatable.toString()}</td> */}
+                <td className="action-table-td left-col">{questAction.repeatable ? "(repeatable) ":""}{questAction.description}</td>
                 <td className="action-table-td right-col">{questAction.xp} xp</td>
                 <td className="action-table-td right-col">
                   <Button variant="dark" onClick={() => acceptQuestAction(questAction)}>Accept</Button>

--- a/client/src/contentpages/myadventures.js
+++ b/client/src/contentpages/myadventures.js
@@ -103,7 +103,6 @@ const MyAdventures = () => {
 
       
       const AvailableQuestAction = ({questAction}) => {
-        console.log(questAction);
         return (
             <tr>
                 <td className="action-table-td left-col">{questAction.description}</td>

--- a/client/src/contentpages/myadventures.js
+++ b/client/src/contentpages/myadventures.js
@@ -103,9 +103,12 @@ const MyAdventures = () => {
 
       
       const AvailableQuestAction = ({questAction}) => {
+        console.log(questAction);
         return (
             <tr>
                 <td className="action-table-td left-col">{questAction.description}</td>
+                {/* todo: figure out the right way to display whether a quest is repeatable here */}
+                {/* <td className="action-table-td left-col">{questAction.repeatable.toString()}</td> */}
                 <td className="action-table-td right-col">{questAction.xp} xp</td>
                 <td className="action-table-td right-col">
                   <Button variant="dark" onClick={() => acceptQuestAction(questAction)}>Accept</Button>

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -644,6 +644,7 @@ struct GuildQuestAction {
     #[serde(rename = "description")]
     name: String,
     xp: u32,
+    repeatable: bool,
 }
 
 /// Get all quest actions associated with a guild.


### PR DESCRIPTION
This PR implements the frontend side of repeatable quests: actually making them and showing that they are repeatable, in the UI.

This PR also fills in a gap in the backend functionality, where I previously forgot to send the `repeatable` field in one endpoint's responses.